### PR TITLE
Add missing const qualifier

### DIFF
--- a/src/unix/open.c
+++ b/src/unix/open.c
@@ -365,7 +365,7 @@ value caml_gr_sigio_handler(void)
 
 /* Processing of graphic errors */
 
-static value * graphic_failure_exn = NULL;
+static const value * graphic_failure_exn = NULL;
 
 void caml_gr_fail(const char *fmt, const char *arg)
 {


### PR DESCRIPTION
This happens on current OpenBSD.
```dune build
      ocamlc src/open.o
src/unix/open.c:375:25: warning: assigning to 'value *' (aka 'long *') from 'const value *' (aka 'const long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    graphic_failure_exn = caml_named_value("Graphics.Graphic_failure");
                        ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
  ocamlmklib src/dllgraphics_stubs.so,src/libgraphics_stubs.a (exit 2)
(cd _build/default && /usr/local/bin/ocamlmklib.opt -g -o src/graphics_stubs src/color.o src/draw.o src/dump_img.o src/events.o src/fill.o src/image.o src/make_img.o src/open.o src/point_col.o src/sound.o src/subwindow.o src/text.o -lX11)
ld: error: unable to find library -lX11
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```