### PR TITLE
Replace call to caml_process_pending_signals by explicit processing of events

### DIFF
--- a/src/unix/events.c
+++ b/src/unix/events.c
@@ -157,13 +157,18 @@ static value caml_gr_wait_allocate_result(int mouse_x, int mouse_y, int button,
 
 static value caml_gr_wait_event_poll(void)
 {
+  XEvent grevent;
   int mouse_x, mouse_y, button, key, keypressed;
   Window rootwin, childwin;
   int root_x, root_y, win_x, win_y;
   unsigned int modifiers;
   unsigned int i;
 
-  caml_process_pending_signals ();
+  /* Process pending X events before polling */
+  while (XCheckMaskEvent(caml_gr_display, -1 /*all events*/, &grevent)) {
+    caml_gr_handle_event(&grevent);
+  }
+  /* Poll the mouse state */
   if (XQueryPointer(caml_gr_display, caml_gr_window.win,
                     &rootwin, &childwin,
                     &root_x, &root_y, &win_x, &win_y,


### PR DESCRIPTION
This is a tentative fix for issue #14 .

`caml_process_pending_signals` is a function from OCaml's runtime system that disappeared in version 4.10.

The reason this function was called in `caml_gr_wait_event_poll` was to process pending X events and merge them in our event queue before the results of the poll are determined.

It should be just as good to explicitly purge pending X events instead.
