### PR TITLE
Use pkg-config to figure out x11 flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+5.1.0 (unreleased)
+------------------
+
+- Use pkg-config to query x11 compilation and linking flags + hardcode
+  a few pkg-config paths for OSX (#..., fixes #16, @diml)
+
+
 5.0.0 (16/09/2019)
 ------------------
 

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -1,0 +1,41 @@
+module C = Configurator.V1
+
+type os = Win32 | Darwin | Other
+
+let os c =
+  let win32 = C.ocaml_config_var c "os_tyle" = Some "Win32" in
+  if win32 then Win32
+  else
+    match C.Process.run c "uname" [ "-s" ] with
+    | { exit_code = 0; stdout; _ } when String.trim stdout = "Darwin" -> Darwin
+    | _ -> Other
+
+let from_pkg_config c =
+  let fallback = ([], [ "-lX11" ]) in
+  match C.Pkg_config.get c with
+  | None -> fallback
+  | Some pc -> (
+      match C.Pkg_config.query pc ~package:"x11" with
+      | None -> fallback
+      | Some { cflags; libs } -> (cflags, libs) )
+
+let () =
+  C.main ~name:"discover" (fun c ->
+      let cflags, libs =
+        match os c with
+        | Other -> from_pkg_config c
+        | Win32 -> ([], [ "-lkernel32"; "-lgdi32"; "-luser32" ])
+        | Darwin ->
+            let pkg_config_path =
+              "/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig"
+            in
+            let pkg_config_path =
+              match Sys.getenv "PKG_CONFIG_PATH" with
+              | exception Not_found -> pkg_config_path
+              | s -> s ^ ":" ^ pkg_config_path
+            in
+            Unix.putenv "PKG_CONFIG_PATH" pkg_config_path;
+            from_pkg_config c
+      in
+      C.Flags.write_sexp "cflags" cflags;
+      C.Flags.write_sexp "libs" libs)

--- a/src/discover/dune
+++ b/src/discover/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries unix dune-configurator))

--- a/src/dune
+++ b/src/dune
@@ -3,30 +3,33 @@
 open StdLabels
 open Jbuild_plugin.V1
 
-let subdir, link_flags =
+let subdir =
   match List.assoc "os_type" ocamlc_config with
-  | "Win32" -> "win32", "-lkernel32 -lgdi32 -luser32"
-| _ -> "unix", "-lX11"
+  | "Win32" -> "win32"
+  | _ -> "unix"
 
 let c_names =
-  Sys.readdir subdir
-  |> Array.to_list
-  |> List.filter ~f:(fun fn ->
-      Filename.check_suffix fn ".c")
+  Sys.readdir subdir |> Array.to_list
+  |> List.filter ~f:(fun fn -> Filename.check_suffix fn ".c")
   |> List.map ~f:Filename.chop_extension
   |> List.sort ~cmp:String.compare
 
 let () =
-  Printf.ksprintf send {|
+  Printf.ksprintf send
+    {|
 (library
  (public_name graphics)
  (wrapped false)
  (synopsis "Portable drawing primitives")
  (c_names %s)
- (c_library_flags %s))
+ (c_flags (:include cflags))
+ (c_library_flags (:include libs)))
 
 (copy_files# %s/*)
+
+(rule
+ (targets cflags libs)
+ (action (run discover/discover.exe)))
 |}
     (String.concat c_names ~sep:" ")
-    link_flags
     subdir


### PR DESCRIPTION
+ add hardcoded pkg-config paths for OSX

Fixes #16
