### PR TITLE
fix typo

### DIFF
--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -3,7 +3,7 @@ module C = Configurator.V1
 type os = Win32 | Darwin | Other
 
 let os c =
-  let win32 = C.ocaml_config_var c "os_tyle" = Some "Win32" in
+  let win32 = C.ocaml_config_var c "os_type" = Some "Win32" in
   if win32 then Win32
   else
     match C.Process.run c "uname" [ "-s" ] with


### PR DESCRIPTION
the dependency on "conf-libX11" and "conf-pkg-config" are also wrong for windows.
But I didn't know, if and how the usual condition operator (`{ os != "win32" }`) is supported inside dune-project, so I've ignored it...