### PR TITLE
Update graphics.opam

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.1)
+(lang dune 2.7)
 (name graphics)
 
 (generate_opam_files true)

--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 
 (generate_opam_files true)
 
-(license "LGPL-2.1 with OCaml linking exception")
+(license "LGPL-2.1-only with OCaml-LGPL-linking-exception")
 (maintainers jeremie@dimino.org david.allsopp@metastack.com)
 (authors "Xavier Leroy"
          "Jun Furuse"

--- a/graphics.opam
+++ b/graphics.opam
@@ -17,14 +17,15 @@ homepage: "https://github.com/ocaml/graphics"
 doc: "https://ocaml.github.io/graphics/"
 bug-reports: "https://github.com/ocaml/graphics/issues"
 depends: [
-  "dune" {>= "2.1"}
+  "dune" {>= "2.7"}
   "dune-configurator"
   "conf-libX11" {os != "win32"}
   "conf-pkg-config" {os != "win32"}
   "ocaml" {>= "4.09.0~~"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/graphics.opam
+++ b/graphics.opam
@@ -12,7 +12,7 @@ maintainer: ["jeremie@dimino.org" "david.allsopp@metastack.com"]
 authors: [
   "Xavier Leroy" "Jun Furuse" "J-M Geffroy" "Jacob Navia" "Pierre Weis"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/graphics"
 doc: "https://ocaml.github.io/graphics/"
 bug-reports: "https://github.com/ocaml/graphics/issues"


### PR DESCRIPTION
A few things picked up in the opam-repository PR for 5.1.2:
- Use the SPDX-compatible name for the licence (linting issue)
- Use `{dev}` instead of `{pinned}` in the subst command