### PR TITLE
Use modern X fonts instead of X core fonts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+- Use modern X fonts instead of X core fonts (#38, @nchataing, Richard Jones)
+- Handle windows closing gracefully under X11 (#42, @xavierleroy)
+
 5.1.2 (24/05/2021)
 ------------------
 

--- a/examples/dune
+++ b/examples/dune
@@ -1,3 +1,3 @@
 (executables
- (names graph_example graph_test sorts)
+ (names font graph_example graph_test sorts)
  (libraries graphics threads))

--- a/examples/font.ml
+++ b/examples/font.ml
@@ -3,7 +3,13 @@ open Graphics
 
 let () =
   open_graph "";
-  set_font "Liberation Mono";
-  moveto 10 10;
+  set_font "monospace";
+  moveto 10 200;
   draw_string "Hello, graphics";
+  set_font "monospace-20";
+  moveto 10 130;
+  draw_string "20 point type";
+  set_font "monospace-40";
+  moveto 10 10;
+  draw_string "40 point type";
   ignore (wait_next_event [Key_pressed])

--- a/examples/font.ml
+++ b/examples/font.ml
@@ -1,0 +1,9 @@
+
+open Graphics
+
+let () =
+  open_graph "";
+  set_font "Liberation Mono";
+  moveto 10 10;
+  draw_string "Hello, graphics";
+  ignore (wait_next_event [Key_pressed])

--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -11,20 +11,13 @@ let os c =
     | _ -> Other
 
 let from_pkg_config c =
-  let fallback = ([], [ "-lX11"; "-lXft" ]) in
+  let fallback = ([], [ "-lXft"; "-lX11" ]) in
   match C.Pkg_config.get c with
   | None -> fallback
   | Some pc ->
-      let packages = [("x11","-lX11"); ("xft", "-lXft")] in
-      let cflags, libs =
-      packages
-      |> List.map (fun (package, fallback) ->
-          match C.Pkg_config.query pc ~package with
-          | None -> [], [fallback]
-          | Some { cflags; libs } -> cflags, libs)
-      |> List.split
-      in
-      List.concat cflags, List.concat libs
+      match C.Pkg_config.query pc ~package:"xft x11" with
+      | None -> fallback
+      | Some { cflags; libs } -> (cflags, libs)
 
 let () =
   C.main ~name:"discover" (fun c ->

--- a/src/unix/events.c
+++ b/src/unix/events.c
@@ -94,8 +94,6 @@ void caml_gr_handle_event(XEvent * event)
       XFillRectangle(caml_gr_display, newbstore.win, newbstore.gc,
                      0, 0, newbstore.w, newbstore.h);
       XSetForeground(caml_gr_display, newbstore.gc, caml_gr_color);
-      if (caml_gr_font != NULL)
-        XSetFont(caml_gr_display, newbstore.gc, caml_gr_font->fid);
 
       /* Copy the old backing store into the new one */
       XCopyArea(caml_gr_display, caml_gr_bstore.win, newbstore.win,

--- a/src/unix/libgraph.h
+++ b/src/unix/libgraph.h
@@ -16,6 +16,8 @@
 #include <stdio.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xft/Xft.h>
+#include <X11/extensions/Xrender.h>
 #include <caml/mlvalues.h>
 #include <caml/misc.h>
 
@@ -37,7 +39,7 @@ extern Bool caml_gr_display_modeflag;     /* Display-mode flag */
 extern Bool caml_gr_remember_modeflag;    /* Remember-mode flag */
 extern int caml_gr_x, caml_gr_y;      /* Coordinates of the current point */
 extern int caml_gr_color;        /* Current *CAML* drawing color (can be -1) */
-extern XFontStruct * caml_gr_font;    /* Current font */
+extern XftFont * caml_gr_font;    /* Current font */
 extern long caml_gr_selected_events;  /* Events we are interested in */
 extern Bool caml_gr_ignore_sigio;     /* Whether to consume events on sigio */
 extern Atom caml_wm_delete_window;    /* "WM_DELETE_WINDOW" atom */

--- a/src/unix/open.c
+++ b/src/unix/open.c
@@ -38,7 +38,7 @@ Bool caml_gr_display_modeflag;
 Bool caml_gr_remember_modeflag;
 int caml_gr_x, caml_gr_y;
 int caml_gr_color;
-extern XFontStruct * caml_gr_font;
+extern XftFont * caml_gr_font;
 long caml_gr_selected_events;
 Bool caml_gr_ignore_sigio = False;
 static Bool caml_gr_initialized = False;
@@ -224,7 +224,8 @@ value caml_gr_close_graph(void)
 #endif
     caml_gr_initialized = False;
     if (caml_gr_font != NULL) {
-      XFreeFont(caml_gr_display, caml_gr_font); caml_gr_font = NULL;
+      XftFontClose(caml_gr_display, caml_gr_font);
+      caml_gr_font = NULL;
     }
     XFreeGC(caml_gr_display, caml_gr_window.gc);
     XDestroyWindow(caml_gr_display, caml_gr_window.win);

--- a/src/unix/text.c
+++ b/src/unix/text.c
@@ -69,6 +69,7 @@ static void caml_gr_draw_text(const char *txt, int len)
     XftDrawString8 (d, &xftcol, caml_gr_font,
         caml_gr_x, Bcvt(caml_gr_y) - caml_gr_font->descent + 1,
         (const FcChar8 *) txt, len);
+    XftDrawDestroy (d);
   }
   if (caml_gr_display_modeflag) {
     d = XftDrawCreate (caml_gr_display, caml_gr_window.win,
@@ -77,9 +78,8 @@ static void caml_gr_draw_text(const char *txt, int len)
         caml_gr_x, Wcvt(caml_gr_y) - caml_gr_font->descent + 1,
         (const FcChar8 *) txt, len);
     XFlush(caml_gr_display);
+    XftDrawDestroy (d);
   }
-
-  if (d) XftDrawDestroy (d);
 
   XftTextExtents8 (caml_gr_display, caml_gr_font,
       (const FcChar8 *) txt, len, &info);

--- a/src/unix/text.c
+++ b/src/unix/text.c
@@ -16,16 +16,22 @@
 #include "libgraph.h"
 #include <caml/alloc.h>
 
-XFontStruct * caml_gr_font = NULL;
+XftFont * caml_gr_font = NULL;
 
 static void caml_gr_get_font(const char *fontname)
 {
-  XFontStruct * font = XLoadQueryFont(caml_gr_display, fontname);
+  XftFont * font;
+
+  /* Is it a X Logical Font Description? LFDs start with a '-' character.
+   * If not, use nicer FontConfig names like "Courier-12".
+   */
+  if (fontname[0] == '-')
+    font = XftFontOpenXlfd (caml_gr_display, caml_gr_screen, fontname);
+  else
+    font = XftFontOpenName (caml_gr_display, caml_gr_screen, fontname);
   if (font == NULL) caml_gr_fail("cannot find font %s", fontname);
-  if (caml_gr_font != NULL) XFreeFont(caml_gr_display, caml_gr_font);
+  if (caml_gr_font != NULL) XftFontClose (caml_gr_display, caml_gr_font);
   caml_gr_font = font;
-  XSetFont(caml_gr_display, caml_gr_window.gc, caml_gr_font->fid);
-  XSetFont(caml_gr_display, caml_gr_bstore.gc, caml_gr_font->fid);
 }
 
 value caml_gr_set_font(value fontname)
@@ -42,18 +48,42 @@ value caml_gr_set_text_size (value sz)
 
 static void caml_gr_draw_text(const char *txt, int len)
 {
+  int rgb;
+  XftColor xftcol;
+  XftDraw *d;
+  Visual *visual = DefaultVisual (caml_gr_display, caml_gr_screen);
+  XGlyphInfo info;
+
+  rgb = caml_gr_rgb_pixel (caml_gr_color);
+  xftcol.pixel = rgb;
+  /* The range of these fields is 0..0xffff */
+  xftcol.color.red = rgb >> 8;;
+  xftcol.color.green = (rgb & 0xff00);
+  xftcol.color.blue = (rgb & 0xff) << 8;
+  xftcol.color.alpha = 0xffff;
+
   if (caml_gr_font == NULL) caml_gr_get_font(DEFAULT_FONT);
-  if (caml_gr_remember_modeflag)
-    XDrawString(caml_gr_display, caml_gr_bstore.win, caml_gr_bstore.gc,
-                caml_gr_x, Bcvt(caml_gr_y) - caml_gr_font->descent + 1, txt,
-                len);
+  if (caml_gr_remember_modeflag) {
+    d = XftDrawCreate (caml_gr_display, caml_gr_bstore.win,
+          visual, caml_gr_colormap);
+    XftDrawString8 (d, &xftcol, caml_gr_font,
+        caml_gr_x, Bcvt(caml_gr_y) - caml_gr_font->descent + 1,
+        (const FcChar8 *) txt, len);
+  }
   if (caml_gr_display_modeflag) {
-    XDrawString(caml_gr_display, caml_gr_window.win, caml_gr_window.gc,
-                caml_gr_x, Wcvt(caml_gr_y) - caml_gr_font->descent + 1, txt,
-                len);
+    d = XftDrawCreate (caml_gr_display, caml_gr_window.win,
+          visual, caml_gr_colormap);
+    XftDrawString8 (d, &xftcol, caml_gr_font,
+        caml_gr_x, Wcvt(caml_gr_y) - caml_gr_font->descent + 1,
+        (const FcChar8 *) txt, len);
     XFlush(caml_gr_display);
   }
-  caml_gr_x += XTextWidth(caml_gr_font, txt, len);
+
+  if (d) XftDrawDestroy (d);
+
+  XftTextExtents8 (caml_gr_display, caml_gr_font,
+      (const FcChar8 *) txt, len, &info);
+  caml_gr_x += info.width;
 }
 
 value caml_gr_draw_char(value chr)
@@ -74,13 +104,14 @@ value caml_gr_draw_string(value str)
 
 value caml_gr_text_size(value str)
 {
-  int width;
+  XGlyphInfo info;
   value res;
   caml_gr_check_open();
   if (caml_gr_font == NULL) caml_gr_get_font(DEFAULT_FONT);
-  width = XTextWidth(caml_gr_font, String_val(str), caml_string_length(str));
+  XftTextExtents8 (caml_gr_display, caml_gr_font,
+      (const FcChar8 *) (String_val(str)), caml_string_length(str), &info);
   res = caml_alloc_small(2, 0);
-  Field(res, 0) = Val_int(width);
-  Field(res, 1) = Val_int(caml_gr_font->ascent + caml_gr_font->descent);
+  Field(res, 0) = Val_int(info.width);
+  Field(res, 1) = Val_int(info.height);
   return res;
 }


### PR DESCRIPTION
This is an actualization of the patch proposed in https://github.com/ocaml/graphics/issues/3 (first issued at https://github.com/ocaml/ocaml/issues/4917), so all credit goes to the original author of the patch (Richard Jones).

I've adapted the machinery to link against the xft library in `discover.ml`, though I have no clue if this is the right way to do it (there may be some other things to tweak for the darwin target).