### PR TITLE
Handle windows closing gracefully under X11

### DIFF
--- a/src/unix/libgraph.h
+++ b/src/unix/libgraph.h
@@ -40,6 +40,7 @@ extern int caml_gr_color;        /* Current *CAML* drawing color (can be -1) */
 extern XFontStruct * caml_gr_font;    /* Current font */
 extern long caml_gr_selected_events;  /* Events we are interested in */
 extern Bool caml_gr_ignore_sigio;     /* Whether to consume events on sigio */
+extern Atom caml_wm_delete_window;    /* "WM_DELETE_WINDOW" atom */
 
 extern Bool caml_gr_direct_rgb;
 extern int caml_gr_byte_order;
@@ -87,3 +88,4 @@ extern void caml_gr_handle_event(XEvent *e);
 extern void caml_gr_init_color_cache(void);
 extern void caml_gr_init_direct_rgb_to_pixel(void);
 extern value caml_gr_id_of_window( Window w );
+extern value caml_gr_close_graph(void);

--- a/src/unix/open.c
+++ b/src/unix/open.c
@@ -125,8 +125,8 @@ value caml_gr_open_graph(value arg)
     /* Handle "please delete window" requests from window manager */
     caml_wm_delete_window =
       XInternAtom(caml_gr_display, "WM_DELETE_WINDOW", False);
-      XSetWMProtocols(caml_gr_display, caml_gr_window.win,
-                      &caml_wm_delete_window, 1);
+    XSetWMProtocols(caml_gr_display, caml_gr_window.win,
+                    &caml_wm_delete_window, 1);
 
     caml_gr_window.gc = XCreateGC(caml_gr_display, caml_gr_window.win, 0, NULL);
     XSetBackground(caml_gr_display, caml_gr_window.gc, caml_gr_background);


### PR DESCRIPTION
Request and process WM_DELETE_WINDOW events, so that clicking on the "close" button is equivalent to calling `Graphics.close_graph`.  Subsequent graphical operations will raise the `Graphic_failure` exception instead of killing the program on an I/O error.  (This is more or less the current behavior of the Win32 implementation of Graphics, if I'm not mistaken.)

In passing, use `XPending` + `XNextEvent` instead of `XCheckMaskEvent(-1)`, as the latter ignores client events such as WM_DELETE_WINDOW.

Fixes: #41 
